### PR TITLE
patch:Add dbcan flexibility

### DIFF
--- a/cazomevolve/__init__.py
+++ b/cazomevolve/__init__.py
@@ -43,7 +43,7 @@
 import logging
 
 
-__version__ = "0.1.7"
+__version__ = "0.1.7.1"
 
 __citation__ = "???"
 

--- a/cazomevolve/cazome/dbcan/get_dbcan_cazymes.py
+++ b/cazomevolve/cazome/dbcan/get_dbcan_cazymes.py
@@ -102,9 +102,14 @@ def get_family_annotations(output_dir, args):
 
         protein_accession = row['Gene ID']
 
-        hmmer_fams = get_tool_fams(row[1])
-        hotpep_fams = get_tool_fams(row[2])
-        diamond_fams = get_tool_fams(row[3])
+        if list(df.columns())[1].startswith('EC#'):
+            hmmer_fams = get_tool_fams(row[2])
+            hotpep_fams = get_tool_fams(row[3])
+            diamond_fams = get_tool_fams(row[4])
+        else:
+            hmmer_fams = get_tool_fams(row[1])
+            hotpep_fams = get_tool_fams(row[2])
+            diamond_fams = get_tool_fams(row[3])
 
         # get the fams at least two tools agreed upon
         dbcan_fams = get_dbcan_consensus(hmmer_fams, hotpep_fams, diamond_fams)

--- a/cazomevolve/cazome/dbcan/get_dbcan_cazymes.py
+++ b/cazomevolve/cazome/dbcan/get_dbcan_cazymes.py
@@ -102,7 +102,7 @@ def get_family_annotations(output_dir, args):
 
         protein_accession = row['Gene ID']
 
-        if list(df.columns())[1].startswith('EC#'):
+        if list(df.columns)[1].startswith('EC#'):
             hmmer_fams = get_tool_fams(row[2])
             hotpep_fams = get_tool_fams(row[3])
             diamond_fams = get_tool_fams(row[4])

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ with Path("README.md").open("r") as long_description_handle:
 
 setuptools.setup(
     name="cazomevolve",
-    version="0.1.7",
+    version="0.1.7.1",
     # Metadata
     author="Emma E. M. Hobbs",
     author_email="eemh1@st-andrews.ac.uk",


### PR DESCRIPTION
When using dbCAN versions 3 and 4, the columns screened in the overview.txt file are different to those in dbCAN 2. 

Previously the code was ignoring the third tool if parsing output from dbCAN v3 or v4. This is now patched and all three tools will be considered regardless of the version of dbCAN used.